### PR TITLE
Add comment to README about the current diagram being from Qweak and NOT MOLLER

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # MOLLER-parity-schema
-Schema for the MOLLER experiment analysis database
+Schema for the MOLLER experiment analysis database. Uses dbml to generically define the schema, which is then turned into the sql for MySQL and postgresql databases. Diagram generated. Versioned at 1.4, per Qweak versioning, so significant changes (likely) would bring us to v2 (semver with backwards incompatible defined as more than addition of nullable fields or addition of tables).
 
 <img src='https://jeffersonlab.github.io/MOLLER-parity-schema/qwparity_schema.svg' alt='MOLLER Parity Schema' />
 
 ## Releases
 
 When a new release is created, SQL commands for MySQL and PostgreSQL are automatically generated from the DBML schema and attached to the release as assets.
+


### PR DESCRIPTION
Expanded the README to include details about the current diagram. The current diagram is based on qweak.